### PR TITLE
Update to node16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set Node.JS
       uses: actions/setup-node@v2
       with:
-        node-version: 12.x
+        node-version: 16.x
 
     - name: Install dependencies
       run: npm install

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ outputs:
   major-tag:
     description: 'The major version tag that has been updated (created). Examples: v1, 1'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 has an end of life on April 30, 2022.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12. 

This is supported on all Actions Runners v2.285.0 or later so we will need to major version the action